### PR TITLE
Add then mode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,29 +90,20 @@ Quirks to note:
 - turns sequence indexing is automatically "modulo length"
 - defined variable names must start with an Uppercase letter; lowercase
   variables can only be used within a rule
-- successive rule results are bitwise `OR`ed together; this could be especially
-  confusing for the result `state` and `color` fields if overlapping rules
-  provide non-zero values
+- successive rule results are bitwise `OR`ed together by default; you can
+  prefix a then field with `=` to instead replace any prior value
 - the pattern matching in the left-hand side is still rudimentary, and supports
   only basic arithmetic
 
 A more complex example:
 ```
-T1 = turns(L S L)
-T2 = turns(R P R)
+T1 = turns(L R)
+T2 = turns(2L 2R)
 0, c => 0, c + 1, T1[c]
 1, c => 1, c - 1, T2[c]
-0, 12 * c => 1, 0, 0
-1, 12 * c => 0, 0, 0
+0, 32 * c => =1, 0, 0
+1, 32 * c => =0, 0, 0
 ```
-
-Features:
-- has two modes (state 0 and 1) with two complementing turn sequences
-- the second mode has the further difference in that it decrements the world
-  color rather than incrementing it like an ant would
-- a mode change happens on every 12-th color
-
-In other words, it's a kind of dual-personality ant and anti-ant in one.
 
 ## Specifying Colors
 

--- a/hexant.js
+++ b/hexant.js
@@ -229,6 +229,7 @@ function reset() {
     this.view.hexGrid.updateSize();
 
     var ent = this.world.ents[0];
+    ent.state = 0;
     ent.dir = 0;
     this.world.tile.centerPoint().toCubeInto(ent.pos);
     var data = this.world.tile.get(ent.pos);

--- a/turmite/lang/build.js
+++ b/turmite/lang/build.js
@@ -94,6 +94,15 @@ module.exports.then = function parseThen(d) {
     };
 };
 
+module.exports.thenVal = function parseThenVal(d) {
+    // TODO: prototype'd object
+    return {
+        type: 'thenVal',
+        mode: d[1],
+        value: d[2]
+    };
+};
+
 module.exports.member = function parseMember(d) {
     return {
         type: 'member',

--- a/turmite/lang/build.js
+++ b/turmite/lang/build.js
@@ -153,3 +153,9 @@ module.exports.item = function item(i) {
         return d[i];
     };
 };
+
+module.exports.just = function just(val) {
+    return function justVal() {
+        return val;
+    };
+};

--- a/turmite/lang/build.js
+++ b/turmite/lang/build.js
@@ -45,7 +45,7 @@ module.exports.turns = function parseTurns(d) {
 module.exports.turn = function parseTurn(d) {
     return {
         type: 'turn',
-        names: [d[1]]
+        names: [d[0]]
     };
 };
 

--- a/turmite/lang/compile.js
+++ b/turmite/lang/compile.js
@@ -229,7 +229,10 @@ function compileThenParts(lines, then, scope) {
 
     var allZero = true;
     var parts = [then.state, then.color, then.turn];
+    var maskParts = [];
+
     for (var i = 0; i < parts.length; i++) {
+        var mode = '|';
         var value = parts[i];
 
         var valStr = compileValue(value, scope);
@@ -251,7 +254,12 @@ function compileThenParts(lines, then, scope) {
         }
     }
 
-    return '';
+    var mask = maskParts.join(' | ');
+    if (maskParts.length > 1) {
+        mask = '(' + mask + ')';
+    }
+
+    return mask;
 }
 
 function compileValue(node, scope, outerPrec) {

--- a/turmite/lang/compile.js
+++ b/turmite/lang/compile.js
@@ -225,6 +225,9 @@ function compileThen(lines, then, scope, body) {
 
 function compileThenParts(lines, then, scope) {
     var valMaxes = ['World.MaxState', 'World.MaxColor', 'World.MaxTurn'];
+    var resMasks = ['World.MaskResultState',
+                    'World.MaskResultColor',
+                    'World.MaskResultTurn'];
     var shifts = ['World.ColorShift', 'World.TurnShift'];
 
     var allZero = true;
@@ -234,6 +237,10 @@ function compileThenParts(lines, then, scope) {
     for (var i = 0; i < parts.length; i++) {
         var mode = parts[i].mode;
         var value = parts[i].value;
+
+        if (mode === '=') {
+            maskParts.push(resMasks[i]);
+        }
 
         var valStr = compileValue(value, scope);
         if (valStr !== '0') {

--- a/turmite/lang/compile.js
+++ b/turmite/lang/compile.js
@@ -208,11 +208,12 @@ function compileThen(lines, then, scope, body) {
     compileThenParts(lines, then, scope);
     var after = lines.length;
 
+    var dest = scope._ent + '.rules[' +
+        scope._key + ' | ' + scope._color +
+    ']';
+
     if (after > before) {
-        lines.push(
-            scope._ent + '.rules[' +
-                scope._key + ' | ' + scope._color +
-            '] |= ' + scope._result + ';');
+        lines.push(dest + ' |= ' + scope._result + ';');
     }
 
     return body(lines);

--- a/turmite/lang/compile.js
+++ b/turmite/lang/compile.js
@@ -219,7 +219,7 @@ function compileThen(lines, then, scope, body) {
 }
 
 function compileThenParts(lines, then, scope) {
-    var masks = ['World.MaxState', 'World.MaxColor', 'World.MaxTurn'];
+    var valMaxes = ['World.MaxState', 'World.MaxColor', 'World.MaxTurn'];
     var shifts = ['World.ColorShift', 'World.TurnShift'];
 
     var allZero = true;
@@ -230,7 +230,7 @@ function compileThenParts(lines, then, scope) {
             if (parts[i].type === 'expr') {
                 value = '(' + value + ')';
             }
-            value += ' & ' + masks[i];
+            value += ' & ' + valMaxes[i];
 
             if (allZero) {
                 allZero = false;

--- a/turmite/lang/compile.js
+++ b/turmite/lang/compile.js
@@ -204,7 +204,7 @@ function freeSymbols(node, scope) {
 }
 
 function compileThen(lines, then, scope, body) {
-    var masks = ['World.MaxState', 'World.MaxColor', 'World.TurnMask'];
+    var masks = ['World.MaxState', 'World.MaxColor', 'World.MaxTurn'];
     var shifts = ['World.ColorShift', 'World.TurnShift'];
 
     var allZero = true;

--- a/turmite/lang/compile.js
+++ b/turmite/lang/compile.js
@@ -232,8 +232,8 @@ function compileThenParts(lines, then, scope) {
     var maskParts = [];
 
     for (var i = 0; i < parts.length; i++) {
-        var mode = '|';
-        var value = parts[i];
+        var mode = parts[i].mode;
+        var value = parts[i].value;
 
         var valStr = compileValue(value, scope);
         if (valStr !== '0') {

--- a/turmite/lang/compile.js
+++ b/turmite/lang/compile.js
@@ -226,18 +226,20 @@ function compileThenParts(lines, then, scope) {
     var allZero = true;
     var parts = [then.state, then.color, then.turn];
     for (var i = 0; i < parts.length; i++) {
-        var value = compileValue(parts[i], scope);
-        if (value !== '0') {
-            if (parts[i].type === 'expr') {
-                value = '(' + value + ')';
+        var value = parts[i];
+
+        var valStr = compileValue(value, scope);
+        if (valStr !== '0') {
+            if (value.type === 'expr') {
+                valStr = '(' + valStr + ')';
             }
-            value += ' & ' + valMaxes[i];
+            valStr += ' & ' + valMaxes[i];
 
             if (allZero) {
                 allZero = false;
-                lines.push(scope._result + ' = ' + value + ';');
+                lines.push(scope._result + ' = ' + valStr + ';');
             } else {
-                lines.push(scope._result + ' |= ' + value + ';');
+                lines.push(scope._result + ' |= ' + valStr + ';');
             }
         }
         if (i < shifts.length && !allZero) {

--- a/turmite/lang/compile.js
+++ b/turmite/lang/compile.js
@@ -204,6 +204,21 @@ function freeSymbols(node, scope) {
 }
 
 function compileThen(lines, then, scope, body) {
+    var before = lines.length;
+    compileThenParts(lines, then, scope);
+    var after = lines.length;
+
+    if (after > before) {
+        lines.push(
+            scope._ent + '.rules[' +
+                scope._key + ' | ' + scope._color +
+            '] |= ' + scope._result + ';');
+    }
+
+    return body(lines);
+}
+
+function compileThenParts(lines, then, scope) {
     var masks = ['World.MaxState', 'World.MaxColor', 'World.MaxTurn'];
     var shifts = ['World.ColorShift', 'World.TurnShift'];
 
@@ -228,15 +243,6 @@ function compileThen(lines, then, scope, body) {
             lines.push(scope._result + ' <<= ' + shifts[i] + ';');
         }
     }
-
-    if (!allZero) {
-        lines.push(
-            scope._ent + '.rules[' +
-                scope._key + ' | ' + scope._color +
-            '] |= ' + scope._result + ';');
-    }
-
-    return body(lines);
 }
 
 function compileValue(node, scope, outerPrec) {

--- a/turmite/lang/compile.js
+++ b/turmite/lang/compile.js
@@ -205,12 +205,16 @@ function freeSymbols(node, scope) {
 
 function compileThen(lines, then, scope, body) {
     var before = lines.length;
-    compileThenParts(lines, then, scope);
+    var mask = compileThenParts(lines, then, scope);
     var after = lines.length;
 
     var dest = scope._ent + '.rules[' +
         scope._key + ' | ' + scope._color +
     ']';
+
+    if (mask) {
+        lines.push(dest + ' &= ~' + mask + ';');
+    }
 
     if (after > before) {
         lines.push(dest + ' |= ' + scope._result + ';');
@@ -246,6 +250,8 @@ function compileThenParts(lines, then, scope) {
             lines.push(scope._result + ' <<= ' + shifts[i] + ';');
         }
     }
+
+    return '';
 }
 
 function compileValue(node, scope, outerPrec) {

--- a/turmite/lang/grammar.ne
+++ b/turmite/lang/grammar.ne
@@ -14,10 +14,16 @@ rule -> when "=>" then  {% build.rule %}
 
 when -> expr "," expr  {% build.when %}
 
-then -> expr "," expr "," thenTurn  {% build.then %}
+then -> thenState "," thenColor "," thenTurn  {% build.then %}
 
-thenTurn -> expr          {% build.item(0) %}
-          | _ turnExpr _  {% build.item(0) %}
+thenMode -> null  {% build.just('|') %}
+
+thenState -> _ thenMode sum _  {% build.thenVal %}
+
+thenColor -> _ thenMode sum _  {% build.thenVal %}
+
+thenTurn -> _ thenMode sum _       {% build.thenVal %}
+          | _ thenMode turnExpr _  {% build.thenVal %}
 
 turnExpr -> turn                   {% build.turn %}
           | turnExpr "|" turnExpr  {% build.multiTurn %}

--- a/turmite/lang/grammar.ne
+++ b/turmite/lang/grammar.ne
@@ -16,10 +16,10 @@ when -> expr "," expr  {% build.when %}
 
 then -> expr "," expr "," thenTurn  {% build.then %}
 
-thenTurn -> expr      {% build.item(0) %}
-          | turnExpr  {% build.item(0) %}
+thenTurn -> expr          {% build.item(0) %}
+          | _ turnExpr _  {% build.item(0) %}
 
-turnExpr -> _ turn _               {% build.turn %}
+turnExpr -> turn                   {% build.turn %}
           | turnExpr "|" turnExpr  {% build.multiTurn %}
 
 expr -> _ sum _  {% build.item(1) %}

--- a/turmite/lang/grammar.ne
+++ b/turmite/lang/grammar.ne
@@ -17,6 +17,7 @@ when -> expr "," expr  {% build.when %}
 then -> thenState "," thenColor "," thenTurn  {% build.then %}
 
 thenMode -> null  {% build.just('|') %}
+          | "|"   {% build.item(0) %}
 
 thenState -> _ thenMode sum _  {% build.thenVal %}
 

--- a/turmite/lang/grammar.ne
+++ b/turmite/lang/grammar.ne
@@ -17,6 +17,7 @@ when -> expr "," expr  {% build.when %}
 then -> thenState "," thenColor "," thenTurn  {% build.then %}
 
 thenMode -> null  {% build.just('|') %}
+          | "="   {% build.item(0) %}
           | "|"   {% build.item(0) %}
 
 thenState -> _ thenMode sum _  {% build.thenVal %}

--- a/turmite/lang/tostring.js
+++ b/turmite/lang/tostring.js
@@ -68,6 +68,16 @@ function toSpecString(root, emit) {
                 join(', ');
                 break;
 
+            case 'thenVal':
+                if (node.mode === '|') {
+                    next();
+                } else {
+                    stack.push(node.mode);
+                    next();
+                    join('');
+                }
+                break;
+
             case 'member':
                 next();
                 wrap('[', ']');

--- a/turmite/lang/walk.js
+++ b/turmite/lang/walk.js
@@ -46,6 +46,10 @@ function iter(root, visit) {
                 each(node.turn);
                 break;
 
+            case 'thenVal':
+                each(node.value);
+                break;
+
             case 'member':
                 each(node.value);
                 each(node.item);

--- a/world.js
+++ b/world.js
@@ -15,7 +15,7 @@ World.MaskFlags   = 0xff00;
 World.MaskColor   = 0x00ff;
 World.MaxState    = 0xff;
 World.MaxColor    = 0xff;
-World.TurnMask    = 0xff;
+World.MaxTurn     = 0xffff;
 
 function World() {
     this.numColors = 0;

--- a/world.js
+++ b/world.js
@@ -7,15 +7,18 @@ var OddQOffset = Coord.OddQOffset;
 
 module.exports = World;
 
-World.StateShift  = 8;
-World.ColorShift  = 8;
-World.TurnShift   = 16;
-World.FlagVisited = 0x0100;
-World.MaskFlags   = 0xff00;
-World.MaskColor   = 0x00ff;
-World.MaxState    = 0xff;
-World.MaxColor    = 0xff;
-World.MaxTurn     = 0xffff;
+World.StateShift      = 8;
+World.ColorShift      = 8;
+World.TurnShift       = 16;
+World.FlagVisited     = 0x0100;
+World.MaskFlags       = 0xff00;
+World.MaskColor       = 0x00ff;
+World.MaxState        = 0xff;
+World.MaxColor        = 0xff;
+World.MaxTurn         = 0xffff;
+World.MaskResultState = 0xff000000;
+World.MaskResultColor = 0x00ff0000;
+World.MaskResultTurn  = 0x0000ffff;
 
 function World() {
     this.numColors = 0;


### PR DESCRIPTION
Rules don't combine as expected; the rule set:

```
0, c => 0, c +1, turns(L R)
1, c => 1, c +1, turns(S P)
0, 8 * c => 1, 0, 0
1, 8 * c => 0, 0, 0
```

Never transitions back to state `0` as intended by the 4th rule due to the bitwise-or combining with the 2nd rule.

However the rule set:

```
0, c => 0, c +1, turns(L R)
1, c => 1, c +1, turns(S P)
0, 8 * c => =1, 0, 0
1, 8 * c => =0, 0, 0
```

Works as intended as it causes rule 4 (and rule 3 for good measure) to first mask out the prior next state before bitwise-oring in the new value.
